### PR TITLE
Fix helm devel flag notice in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Crossplane is a framework for building your own [control plane](https://docs.upb
    helm install crossplane --namespace crossplane-system --create-namespace upbound-stable/crossplane --devel
    ```
 
-   > [!NOTE]
-   > Helm requires the use of `--devel` flag for versions with suffixes, like `v2.0.1-up.1`. The Helm repository Upbound uses
-   > is the stable repository, so use of that flag is only a workaround. You will always get the latest stable version of
-   > Upbound Crossplane.
+> [!NOTE]
+> Helm requires the use of `--devel` flag for versions with suffixes, like `v2.0.1-up.1`. The Helm repository Upbound uses
+> is the stable repository, so use of that flag is only a workaround. You will always get the latest stable version of
+> Upbound Crossplane.
 
 ### Upgrade from upstream Crossplane
 


### PR DESCRIPTION
### Description of your changes

Fix helm devel flag notice in readme.

<img width="891" height="153" alt="Screenshot 2025-08-12 at 15 35 27" src="https://github.com/user-attachments/assets/540d8a00-2b25-401d-9d11-e6def5199f91" />

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

View file from PR.